### PR TITLE
Add /bug command to Rust CLI

### DIFF
--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -54,6 +54,8 @@ tui-markdown = "0.3.3"
 tui-textarea = "0.7.0"
 unicode-segmentation = "1.12.0"
 uuid = "1"
+os_info = "3"
+url = "2"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -54,7 +54,6 @@ tui-markdown = "0.3.3"
 tui-textarea = "0.7.0"
 unicode-segmentation = "1.12.0"
 uuid = "1"
-os_info = "3"
 url = "2"
 
 [dev-dependencies]

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -247,6 +247,12 @@ impl<'a> App<'a> {
                             tracing::error!("Failed to toggle mouse mode: {e}");
                         }
                     }
+                    SlashCommand::Bug => {
+                        if let AppState::Chat { widget } = &mut self.app_state {
+                            let url = widget.bug_report_url();
+                            widget.push_background_message(format!("\u{1F517} Bug report URL: {}", url));
+                        }
+                    }
                     SlashCommand::Quit => {
                         break;
                     }

--- a/codex-rs/tui/src/bug_report.rs
+++ b/codex-rs/tui/src/bug_report.rs
@@ -1,0 +1,42 @@
+use url::form_urlencoded::Serializer;
+
+#[derive(Debug)]
+pub struct BugReportStep {
+    pub message: String,
+    pub reasoning: usize,
+    pub tool_calls: usize,
+}
+
+pub fn build_bug_report_url(
+    steps: &[BugReportStep],
+    version: &str,
+    model: &str,
+    platform: &str,
+) -> String {
+    let mut serializer = Serializer::new(String::new());
+    serializer.append_pair("template", "2-bug-report.yml");
+    serializer.append_pair("labels", "bug");
+    serializer.append_pair("version", version);
+    serializer.append_pair("model", model);
+    serializer.append_pair("platform", platform);
+
+    if !steps.is_empty() {
+        let mut bullets = String::new();
+        for step in steps {
+            if !bullets.is_empty() {
+                bullets.push('\n');
+            }
+            let msg = step.message.replace('\n', " ");
+            bullets.push_str(&format!(
+                "- ```\n  {}\n  ```\n  - `{}` reasoning | `{}` tool",
+                msg, step.reasoning, step.tool_calls
+            ));
+        }
+        serializer.append_pair("steps", &bullets);
+    }
+
+    format!(
+        "https://github.com/openai/codex/issues/new?{}",
+        serializer.finish()
+    )
+}

--- a/codex-rs/tui/src/bug_report.rs
+++ b/codex-rs/tui/src/bug_report.rs
@@ -28,7 +28,7 @@ pub fn build_bug_report_url(
             }
             let msg = step.message.replace('\n', " ");
             bullets.push_str(&format!(
-                "- ```\n  {}\n  ```\n  - `{}` reasoning | `{}` tool",
+                "- ```\n  {}\n  ```\n  - `{}` reasoning | `{}` tool`",
                 msg, step.reasoning, step.tool_calls
             ));
         }

--- a/codex-rs/tui/src/bug_report.rs
+++ b/codex-rs/tui/src/bug_report.rs
@@ -28,8 +28,10 @@ pub fn build_bug_report_url(
             }
             let msg = step.message.replace('\n', " ");
             bullets.push_str(&format!(
-                "- ```\n  {}\n  ```\n  - `{}` reasoning | `{}` tool`",
-                msg, step.reasoning, step.tool_calls
+                "- ```\n  {}\n  ```\n  - `{}` reasoning | `{}` tool calls",
+                msg,
+                step.reasoning,
+                step.tool_calls,
             ));
         }
         serializer.append_pair("steps", &bullets);

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -399,8 +399,20 @@ impl ChatWidget<'_> {
     pub(crate) fn bug_report_url(&self) -> String {
         use crate::bug_report::{build_bug_report_url, BugReportStep};
         let steps = self.conversation_history.bug_report_steps();
-        let os = std::env::consts::OS;
-        let arch = std::env::consts::ARCH;
+        let os = std::process::Command::new("uname")
+            .arg("-s")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_lowercase())
+            .unwrap_or_else(|| std::env::consts::OS.to_string());
+        let arch = std::process::Command::new("uname")
+            .arg("-m")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .map(|s| s.trim().to_string())
+            .unwrap_or_else(|| std::env::consts::ARCH.to_string());
         let release = std::process::Command::new("uname")
             .arg("-r")
             .output()

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -18,7 +18,6 @@ use codex_core::protocol::McpToolCallEndEvent;
 use codex_core::protocol::Op;
 use codex_core::protocol::PatchApplyBeginEvent;
 use codex_core::protocol::TaskCompleteEvent;
-use os_info;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
@@ -400,12 +399,19 @@ impl ChatWidget<'_> {
     pub(crate) fn bug_report_url(&self) -> String {
         use crate::bug_report::{build_bug_report_url, BugReportStep};
         let steps = self.conversation_history.bug_report_steps();
-        let info = os_info::get();
+        let os = std::env::consts::OS;
+        let arch = std::env::consts::ARCH;
+        let release = std::process::Command::new("uname")
+            .arg("-r")
+            .output()
+            .ok()
+            .and_then(|o| String::from_utf8(o.stdout).ok())
+            .unwrap_or_else(|| "unknown".into());
         let platform = format!(
             "`{}` | `{}` | `{}`",
-            info.os_type(),
-            std::env::consts::ARCH,
-            info.version()
+            os,
+            arch,
+            release.trim()
         );
 
         build_bug_report_url(

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -37,6 +37,7 @@ mod markdown;
 mod mouse_capture;
 mod scroll_event_helper;
 mod slash_command;
+mod bug_report;
 mod status_indicator_widget;
 mod text_block;
 mod text_formatting;

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -15,6 +15,7 @@ pub enum SlashCommand {
     New,
     ToggleMouseMode,
     Quit,
+    Bug,
 }
 
 impl SlashCommand {
@@ -26,6 +27,7 @@ impl SlashCommand {
                 "Toggle mouse mode (enable for scrolling, disable for text selection)"
             }
             SlashCommand::Quit => "Exit the application.",
+            SlashCommand::Bug => "Generate a bug report URL.",
         }
     }
 


### PR DESCRIPTION
## Summary
- implement bug report URL builder for codex-tui
- collect conversation steps to summarise a session
- expose `/bug` slash command and show generated URL
- add needed dependencies

## Testing
- `cargo check --locked -p codex-tui` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_68478da1c148833194f63ec54cfeae0d